### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 - [AppMap Maven plugin](#appmap-maven-plugin)
   - [Quickstart](#quickstart)
   - [About](#about)
-    - [Typical entry in pom.xml](#typical-entry-in-pomxml)
   - [Plugin goals](#plugin-goals)
   - [Plugin configuration](#plugin-configuration)
-    - [Configuration example](#configuration-example)
-  - [Running](#running)
+  - [Troubleshooting](#troubleshooting)
+  - [Running without modifying `pom.xml`](#running-without-modifying-pomxml)
 
 ## Quickstart
 
@@ -38,25 +37,7 @@ packages:
   # - exclude: com.myorganization.myapplication.MyClass.myStaticMethod
 ```
 
-Next, run your tests with the `com.appland:appmap-maven-plugin:prepare-agent`
-goal to load the AppMap agent into your test execution and record tests:
-
-```sh
-mvn com.appland:appmap-maven-plugin:prepare-agent test
-```
-
-Continue on to add AppMap to your `pom.xml` as a plugin.
-
-## About
-
-The AppMap Maven Plugin provides simple method for recording AppMaps in running
-tests in Maven projects and a seamless integration into CI/CD pipelines. The
-recording agent requires `appmap.yml` configuration file, see
-[appmap-java](https://github.com/applandinc/appmap-java/blob/master/README.md)
-for details.
-
-### Typical entry in pom.xml
-
+Next, add the following plugin definition to your `pom.xml`:
 ```xml
 <!-- the plugin element goes to build/plugins -->
 <!-- AppMap agent, default parameters -->
@@ -74,6 +55,20 @@ for details.
 </plugin>
 ```
 
+That's all! The AppMap agent will automatically record your tests when you run
+`mvn test`. By default, AppMap files are output to `target/appmap`.
+
+Using Visual Studio Code? [Download the AppMap extension](https://marketplace.visualstudio.com/items?itemName=appland.appmap)
+to view AppMap files in your IDE.
+
+## About
+
+The AppMap Maven Plugin provides simple method for recording AppMaps in running
+tests in Maven projects and a seamless integration into CI/CD pipelines. The
+recording agent requires `appmap.yml` configuration file, see
+[appmap-java](https://github.com/applandinc/appmap-java/blob/master/README.md)
+for details.
+
 ## Plugin goals
 
 - `prepare-agent` - adds the AppMap Java agent to the JVM
@@ -84,42 +79,46 @@ for details.
 - `outputDirectory` Output directory for `.appmap.json` files. Default:
   _./target/appmap_
 - `skip` Agent won't record tests when set to true. Default: _false_
-- `debug` Enable debug flags as a comma separated list. Accepts: `info`, `hooks`, `http`, `locals` Default: _null_ (disabled)
-- `debugFile` Specify where to output debug logs. Default: _target/appmap/agent.log_
+- `debug` Enable debug flags as a comma separated list. Accepts: `info`,
+  `hooks`, `http`, `locals` Default: _info_
+- `debugFile` Specify where to output debug logs. Default:
+  _target/appmap/agent.log_
 - `eventValueSize` Specifies the length of a value string before truncation
   occurs. If set to 0, truncation is disabled. Default: _1024_
 
-### Configuration example
+## Troubleshooting
 
-```xml
-<!-- AppMap Java agent, all parameters -->
-<plugin>
-    <groupId>com.appland</groupId>
-    <artifactId>appmap-maven-plugin</artifactId>
-    <configuration>
-        <configFile>appmap.yml</configFile>
-        <outputDirectory>target/appmap</outputDirectory>
-        <skip>false</skip>
-        <debug></debug>
-        <debugFile>target/appmap/agent.log</debugFile>
-        <eventValueSize>1024</eventValueSize>
-    </configuration>
-    <executions>
-        <execution>
-            <phase>process-test-classes</phase>
-            <goals>
-                <goal>prepare-agent</goal>
-            </goals>
-        </execution>
-    </executions>
-</plugin>
+**I have no `target/appmap` directory**  
+  It's likely that the agent is not running. Double check the `prepare-agent`
+  goal is being run. If the JVM is being forked at any point, make sure the
+  `javaagent` argument is being propagated to the new process.
+
+**`*.appmap.json` files are present, but appear empty or contain little data**  
+  Double check your `appmap.yml`. This usually indicates that the agent is
+  functioning as expected, but no classes or methods referenced in the
+  `appmap.yml` configuration are being executed. You may need to adjust the
+  packages being recorded. Follow this link for more information:
+  https://github.com/applandinc/appmap-java#configuration
+
+**My tests aren't running or I'm seeing `The forked VM terminated without
+  properly saying goodbye.`**  
+  Check the agent log (defaults to `target/appmap/agent.log`) and/or the
+  Maven Surefire dumpstream (`target/surefire-reports/${DATETIME}.dumpstream`).
+  This is typically indicative of an invalid `appmap.yml` configuration.
+
+**I have a test failure that only occurs while the agent is attached**  
+  Please open an issue at [applandinc/appmap-java](https://github.com/applandinc/appmap-java/issues).
+  Attach a link to the source code or repository (if available), as well as any
+  other relevant information including:
+  - the contents of `appmap.yml`
+  - the run command used (such as `mvn test`)
+  - output of the run command
+  - any Maven Surefire dumpstreams generated
+    (`target/surefire-reports/${DATETIME}.dumpstream`)
+
+## Running without modifying `pom.xml`
+By specifying the fully-qualified goal, the agent can be run without any
+additional configuration:
+```sh
+mvn com.appland:appmap-maven-plugin:prepare-agent test
 ```
-
-## Running
-
-With the [above configuration](#configuration-example) added to your `pom.xml`,
-AppMaps will be automatically recorded when the agent is active and tests are
-run.
-
-Alternatively, you can load the AppMap agent without modifying your `pom.xml`.
-See the [Quickstart](#quickstart) section for more information.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ for details.
 - `outputDirectory` Output directory for `.appmap.json` files. Default:
   _./target/appmap_
 - `skip` Agent won't record tests when set to true. Default: _false_
-- `debug` Enable debug logging. Default: _false_
+- `debug` Enable debug flags as a comma separated list. Accepts: `info`, `hooks`, `http`, `locals` Default: _null_ (disabled)
 - `debugFile` Specify where to output debug logs. Default: _target/appmap/agent.log_
 - `eventValueSize` Specifies the length of a value string before truncation
   occurs. If set to 0, truncation is disabled. Default: _1024_
@@ -100,7 +100,7 @@ for details.
         <configFile>appmap.yml</configFile>
         <outputDirectory>target/appmap</outputDirectory>
         <skip>false</skip>
-        <debug>false</debug>
+        <debug></debug>
         <debugFile>target/appmap/agent.log</debugFile>
         <eventValueSize>1024</eventValueSize>
     </configuration>

--- a/src/main/java/com/appland/appmap/AppMapAgentMojo.java
+++ b/src/main/java/com/appland/appmap/AppMapAgentMojo.java
@@ -64,7 +64,7 @@ public abstract class AppMapAgentMojo extends AbstractMojo {
         List<String> args = new ArrayList<String>();
         final String oldConfig = getCurrentArgLinePropertyValue();
         if (oldConfig != null) {
-            final List<String> oldArgs = Arrays.asList(oldConfig.split(" "));
+            final List<String> oldArgs = new ArrayList<>(Arrays.asList(oldConfig.split(" ")));
             removeOldAppMapAgentFromCommandLine(oldArgs);
             args.addAll(oldArgs);
         }

--- a/src/main/java/com/appland/appmap/AppMapAgentMojo.java
+++ b/src/main/java/com/appland/appmap/AppMapAgentMojo.java
@@ -16,6 +16,7 @@ public abstract class AppMapAgentMojo extends AbstractMojo {
 
     static final String APPMAP_AGENT_ARTIFACT_NAME = "com.appland:appmap-agent";
     static final String SUREFIRE_ARG_LINE = "argLine";
+    static final List<String> DEBUG_FLAGS = Arrays.asList("hooks", "locals", "http");
 
     @Parameter(property = "skip")
     protected boolean skip = false;
@@ -27,7 +28,7 @@ public abstract class AppMapAgentMojo extends AbstractMojo {
     protected File configFile = new File("appmap.yml");
 
     @Parameter(property = "project.debug")
-    protected Boolean debug = false;
+    protected String debug = "info";
 
     @Parameter(property = "project.debugFile")
     protected File debugFile = new File("target/appmap/agent.log");
@@ -97,7 +98,14 @@ public abstract class AppMapAgentMojo extends AbstractMojo {
                 format("-javaagent:%s=%s", getAppMapAgentJar(), this)
         ));
 
-        if (this.debug) {
+        if (this.debug != null && !this.debug.isEmpty()) {
+            final List<String> debugTokens = new ArrayList<>(Arrays.asList(this.debug.split("[,|\\s]")));
+            for (String token : debugTokens) {
+                if (DEBUG_FLAGS.contains(token)) {
+                    args.add("-Dappmap.debug." + token);
+                }
+            }
+
             args.add(0, "-Dappmap.debug");
             args.add(0, "-Dappmap.debug.file=" + StringEscapeUtils.escapeJava(format("%s", debugFile)));
         }


### PR DESCRIPTION
1. Additional debug logging can now be enabled by setting the `debug` property:
```xml
<configuration>
  <debug>hooks,locals</debug>
<configuration>
```

2. When loading the plugin twice (via `pom.xml` and the remote goal) an exception will no longer be raised.
3. The README has been changed to improve consistency when getting started.