### PR TITLE
ci(gradle): use Gradle Nexus Publishing plugin

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -18,7 +18,9 @@ plugins:
         - CHANGELOG.md
         - build.gradle
   - - '@semantic-release/exec'
-    - publishCmd: ./gradlew publish
+    #- publishCmd: ./gradlew publish
+    #- publishCmd: ./gradlew publishToSonatype closeSonatypeStagingRepository
+    - publishCmd: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
   - - '@semantic-release/github'
     - assets:
         - build/libs/*.jar

--- a/CI-README.md
+++ b/CI-README.md
@@ -40,11 +40,10 @@ bash expression on the stdout. The result could be sored in Travis UI.
 
 ## Manual
 
-`./gradlew publish`
+`./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository`
 
 ## CI
 
-1. Configure Travis (integration plus repo-level variables)
-2. Pushs tag in the form `Х.Y[.Z[-WHATEVER]]`. (`-SNAPSHOT` suffix generates Maven snapshots
-
-
+upon commit to `master` branch, semantic-release bumps version (if needed) 
+and uses Gradle Nexus Publishing plugin to perform full set of steps 
+required to propagate release to Maven Central repo via OSSRH

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'maven'
     id 'signing'
     id 'maven-publish'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
 }
 
 // parameterization
@@ -40,6 +41,9 @@ def versionLikeRegexp   = /^\d+\.\d+.*/
 def travisVersionOK     = travisVersion && (travisVersion ==~ versionLikeRegexp)
 paramVersion = paramVersion ?: ( travisVersionOK ? travisVersion : defVersion )
 
+// required by NexusPublishing
+version = paramVersion
+group   = paramGroupId
 
 repositories {
   mavenCentral()
@@ -205,25 +209,18 @@ publishing {
         }
   }
 
-   repositories {
-        def local_url       = "file://${buildDir}/repo"
-        def staging_url     = paramMavenRepo + "/service/local/staging/deploy/maven2/"
-        def snapshots_url   = paramMavenRepo + "/content/repositories/snapshots/"
-        def is_snapshot     = paramVersion.endsWith('SNAPSHOT')
-        def remote_url      = is_snapshot  ? snapshots_url : staging_url
+}
 
-        maven {
-            if (paramRepoUsername) {
-                url = remote_url
-                credentials {
-                    username = paramRepoUsername
-                    password = paramRepoPassword
-                }
-            } else {
-                url = local_url
-            }
+nexusPublishing {
+    repositories {
+        sonatype { 
+            nexusUrl                = uri(  paramMavenRepo + "/service/local/")
+            snapshotRepositoryUrl   = uri(  paramMavenRepo + "/content/repositories/snapshots" )        
+            username                = paramRepoUsername
+            password                = paramRepoPassword
         }
     }
+
 }
 
 


### PR DESCRIPTION
Use Gradle Nexus Publishing to streamline publications to Maven Central (full automation of close and release steps)