### PR TITLE
fix: Allow spaces in `javaagent` path

### DIFF
--- a/src/main/java/com/appland/appmap/maven/AppMapAgentMojo.java
+++ b/src/main/java/com/appland/appmap/maven/AppMapAgentMojo.java
@@ -6,7 +6,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import java.io.File;
 import java.util.*;
 
 public abstract class AppMapAgentMojo extends AbstractMojo {

--- a/src/main/java/com/appland/appmap/maven/LoadJavaAppMapAgentMojo.java
+++ b/src/main/java/com/appland/appmap/maven/LoadJavaAppMapAgentMojo.java
@@ -83,6 +83,10 @@ public class LoadJavaAppMapAgentMojo extends AppMapAgentMojo {
         return builder.toString();
     }
 
+    private String javaAgentArgLine() {
+        return format("\"-javaagent:%s\"", StringEscapeUtils.escapeJava(getAppMapAgentJarPath()));
+    }
+
     /**
      * Generate required quotes JVM argument based on current configuration and
      * prepends it to the given argument command line. If a agent with the same
@@ -90,14 +94,12 @@ public class LoadJavaAppMapAgentMojo extends AppMapAgentMojo {
      * command line.
      */
     private void removeOldAppMapAgentFromCommandLine(List<String> oldArgs) {
-        final String plainAgent = format("-javaagent:%s", getAppMapAgentJarPath());
+        final String plainAgent = this.javaAgentArgLine();
         oldArgs.removeIf(oldCommand -> oldCommand.startsWith(plainAgent));
     }
 
     private void addMvnAppMapCommandLineArgsFirst(List<String> args) {
-        args.add(StringEscapeUtils.escapeJava(
-            format("-javaagent:%s", getAppMapAgentJarPath())
-        ));
+        args.add(this.javaAgentArgLine());
 
         if (this.debug != null && !this.debug.isEmpty()) {
             final List<String> debugTokens = new ArrayList<>(Arrays.asList(this.debug.split("[,|\\s]")));


### PR DESCRIPTION
This change wraps the `javaagent` arg line in quotes, in case the path contains spaces.

Resolves #25 